### PR TITLE
CTCP-131: Updated header and cookie banner

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -26,8 +26,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration, service: Servic
   val contactHost: String                  = configuration.get[String]("contact-frontend.host")
   val contactFormServiceIdentifier: String = "CTCTraders"
 
-  val trackingConsentUrl: String = configuration.get[String]("microservice.services.tracking-consent-frontend.url")
-  val gtmContainer: String       = configuration.get[String]("microservice.services.tracking-consent-frontend.gtm.container")
+  val trackingConsentUrl: String = configuration.get[String]("tracking-consent-frontend.url")
+  val gtmContainer: String       = configuration.get[String]("tracking-consent-frontend.gtm.container")
 
   val userResearchUrl: String         = configuration.get[String]("urls.userResearch")
   val showUserResearchBanner: Boolean = configuration.get[Boolean]("banners.showUserResearch")

--- a/app/views/templates/MainTemplate.scala.html
+++ b/app/views/templates/MainTemplate.scala.html
@@ -79,9 +79,7 @@
 
 @hmrcLayout(
     pageTitle = Some(breadCrumbTitle(title, mainContent)),
-    additionalHeadBlock = Some(hmrcHead(
-        headBlock = Some(headScripts)
-    )),
+    additionalHeadBlock = Some(headScripts),
     userResearchBannerUrl = if (appConfig.showUserResearchBanner) Some(appConfig.userResearchUrl) else None,
     serviceName = Some(messages("site.service_name")),
     serviceUrl = Some(appConfig.loginContinueUrl),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,10 +76,6 @@ microservice {
         host = localhost
         port = 9481
     }
-    tracking-consent-frontend {
-      gtm.container = "b"
-      url = "http://localhost:12345/tracking-consent/tracking.js"
-    }
   }
 }
 
@@ -121,7 +117,7 @@ mongodb {
 
 urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:10122/manage-transit-movements/cancellation"
+  loginContinue = "http://localhost:9485/manage-transit-movements"
   logout        = "http://localhost:9553/bas-gateway/sign-out-without-state"
   logoutContinue = "http://localhost:9553/bas-gateway/sign-out-without-state?continue="
   feedback = "http://localhost:9514/feedback/manage-transit-departures"
@@ -130,6 +126,11 @@ urls {
   eccEnrolmentSplashPage = "http://localhost:6750/customs-enrolment-services/ctc/subscribe"
   userResearch = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=List_CTC&utm_source=&utm_medium=other&t=HMRC&id=266"
   nctsHelpdesk = "https://www.gov.uk/new-computerised-transit-system"
+}
+
+tracking-consent-frontend {
+  gtm.container = "b"
+  url = "http://localhost:12345/tracking-consent/tracking.js"
 }
 
 banners {

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -65,7 +65,7 @@ trait ViewBehaviours extends SpecBase with ViewSpecAssertions {
   "must render service name link in header" in {
     val link = getElementByClass(doc, "hmrc-header__service-name--linked")
     assertElementContainsText(link, "Manage your transit movements")
-    assertElementContainsHref(link, "http://localhost:10122/manage-transit-movements/cancellation")
+    assertElementContainsHref(link, "http://localhost:9485/manage-transit-movements")
   }
 
   "must append service to feedback link" in {


### PR DESCRIPTION
Before:

* The cookie banner was not showing.
* The header link on the page was a dead link.

After:

* The cookie banner shows correctly (required moving the tracking-consent-frontend config to root level).
* The header link points at the manage fe home page.